### PR TITLE
feat: add lefthook for blocking sensitive files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+setup:
+	go install github.com/evilmartians/lefthook@v1.11.3
+	lefthook install

--- a/README.md
+++ b/README.md
@@ -92,5 +92,18 @@ This command exports data with relation properties showing the related page name
 1. Open the Notion database in your browser.
 2. The database ID is the part of the URL between `/` and `?` or the last part after `/` if there is no query string.
 
+## Development
+Before starting development, run the following command:
+
+```sh
+make setup
+```
+
+This command will:
+- Install lefthook for pre-commit hooks to prevent accidental commits of sensitive files
+
+### Pre-commit Hooks
+This project uses [lefthook](https://github.com/evilmartians/lefthook) to manage Git hooks. The pre-commit hooks help prevent accidental commits of sensitive files.
+
 ## License
 This project is licensed under the MIT License. See the LICENSE file for details.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+pre-commit:
+  parallel: true
+  commands:
+    block-sensitive-files:
+      run: >
+        bash -c '
+        for file in {staged_files}; do
+          if [[ "$file" =~ \.(csv|xls|xlsx|pdf)$ ]]; then
+            echo "ERROR: Sensitive file detected: $file";
+            exit 1;
+          fi;
+        done'
+      exclude: '^allowed/.*\.(csv|xls|xlsx|pdf)$'


### PR DESCRIPTION
## Changes
- Introduce Git hooks using lefthook
- Implement protection against accidental commits of sensitive files (.csv, .xls, .xlsx, .pdf)
- Add development environment setup instructions

## Key Updates
1. Added `Makefile`
   - Enable `make setup` command for lefthook installation and initialization

2. Added `lefthook.yml`
   - Configure pre-commit hooks
   - Implement blocking mechanism for sensitive files
   - Set exclusion rules for allowed directory (allowed/)

3. Updated `README.md`
   - Add development environment setup instructions
   - Document Git hook functionality with lefthook

## Purpose
- Enhance security by preventing accidental commits of potentially sensitive files

## Evidence
- [x] blocked csv file commiting.
	![image](https://github.com/user-attachments/assets/2c88fc5f-4414-4d48-ac88-dd06883ff266)
